### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -1,6 +1,6 @@
 name: Bug report 🐛
 description: Create a bug report for MUI Design kits.
-labels: ['status: needs triage']
+labels: ["status: needs triage"]
 body:
   - type: markdown
     attributes:
@@ -52,4 +52,10 @@ body:
   - type: textarea
     attributes:
       label: Your environment 🌎
-      description: The version of the design file you are using. The version is usually disabled in the footer of the design frames.
+      description: Help us reproduce the issue.
+      value: |
+        | Software            | Version               |
+        | ------------------- | --------------------- |
+        | Design file version | v5.?.?                |
+        | Design tool         | Figma/Adobe XD/Sketch |
+        | etc.                |                       |

--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -1,0 +1,55 @@
+name: Bug report 🐛
+description: Create a bug report for MUI Design kits.
+labels: ['status: needs triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/mui/mui-design-kits/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Latest version
+      description: We roll bug fixes and other improvements into new releases.
+      options:
+        - label: I have tested the latest version
+          required: true
+  - type: textarea
+    attributes:
+      label: Current behavior 😯
+      description: Describe what happens instead of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Expected behavior 🤔
+      description: Describe what should happen.
+  - type: textarea
+    attributes:
+      label: Steps to reproduce 🕹
+      description: |
+        Please provide a link to a live example and an unambiguous set of steps to reproduce this bug.
+
+        Issues that we can't reproduce will be closed.
+      value: |
+        Link to live example:
+
+        Steps:
+        1.
+        2.
+        3.
+        4.
+  - type: textarea
+    attributes:
+      label: Context 🔦
+      description: What are you trying to accomplish? How has this issue affected you? Providing context helps us come up with a solution that is more useful in the real world.
+  - type: textarea
+    attributes:
+      label: Your environment 🌎
+      description: The version of the design file you are using. The version is usually disabled in the footer of the design frames.

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -1,0 +1,36 @@
+name: Feature request 💄
+description: Suggest a new idea for MUI Design kits.
+labels: ['status: needs triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/mui/mui-design-kits/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Latest version
+      description: We roll bug fixes, performance enhancements, and other improvements into new releases.
+      options:
+        - label: I have tested the latest version
+          required: true
+  - type: textarea
+    attributes:
+      label: Summary 💡
+      description: Describe how it should work.
+  - type: textarea
+    attributes:
+      label: Examples 🌈
+      description: Provide a link to the Material Design specification, other implementations, or screenshots of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Motivation 🔦
+      description: What are you trying to accomplish? How has the lack of this feature affected you? Providing context helps us come up with a solution that is more useful in the real world.

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -29,7 +29,7 @@ body:
   - type: textarea
     attributes:
       label: Examples 🌈
-      description: Provide a link to the Material Design specification, other implementations, or screenshots of the expected behavior.
+      description: Provide a link for appropriate benchmarks, such as Material Design or other design system's implementations, and screenshots/videos of the expected behavior.
   - type: textarea
     attributes:
       label: Motivation 🔦

--- a/.github/ISSUE_TEMPLATE/3.support.yml
+++ b/.github/ISSUE_TEMPLATE/3.support.yml
@@ -1,0 +1,32 @@
+name: 'Support question ❔'
+description: I can't find a solution to my problem with MUI Design kit.
+title: "[question] "
+labels: ['status: needs triage', 'support: question']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        ⚠️ **Don't use this form if the problem is [a bug](https://github.com/mui/mui-design-kits/issues/new?assignees=&labels=status%3A+needs+triage&template=1.bug.yml) or a [feature request](https://github.com/mui/mui-design-kits/issues/new?assignees=&labels=status%3A+needs+triage&template=2.feature.yml), use the dedicated form instead.**
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/mui/mui-design-kits/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Latest version
+      description: We roll bug fixes, performance enhancements, and other improvements into new releases.
+      options:
+        - label: I have tested the latest version
+          required: true
+  - type: textarea
+    attributes:
+      label: The problem in depth 🔍
+  - type: textarea
+    attributes:
+      label: Your environment 🌎
+      description: The version of the design file you are using. The version is usually disabled in the footer of the design frames.

--- a/.github/ISSUE_TEMPLATE/4.rfc.yml
+++ b/.github/ISSUE_TEMPLATE/4.rfc.yml
@@ -1,0 +1,43 @@
+name: RFC 💬
+description: Request for comments for your proposal.
+title: "[RFC] "
+labels: ['RFC']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the RFC in the title above ⬆️.
+
+        Thanks for contributing by creating an RFC! ❤️
+  - type: textarea
+    attributes:
+      label: What's the problem? 🤔
+      description: A short paragraph or bullet list that quickly explains what you're trying to do, what value do we expect to get or any other relevant information to understand motivation behind this RFC.
+  - type: textarea
+    attributes:
+      label: What are the requirements? ❓
+      description: Provide a list of requirements that should be met by the accepted proposal.
+  - type: textarea
+    attributes:
+      label: What are our options? 💡
+      description: |
+        Have you considered all options that we can achieve same/similar thing? It doesn't have to be explored in same detail as the main proposal, but having alternative options that you can present can help strengthen main proposal.
+
+        Consider:
+        - using diagrams to help illustrate your ideas
+        - including code examples if you're proposing an interface or system contract
+        - linking to project briefs or wireframes that are relevant
+  - type: textarea
+    attributes:
+      label: Proposed solution 🟢
+      description: |
+        This is the core of RFC, and its purpose is to clearly explain reasoning for the proposed solution, why it's better compared to the other options or why should it be chosen instead.
+
+        Consider:
+        - using diagrams to help illustrate your ideas
+        - including code examples if you're proposing an interface or system contract
+        - linking to project briefs or wireframes that are relevant
+  - type: textarea
+    attributes:
+      label: Relevant resources/benchmarks 🔗
+      description: Attach any issues, PRs, links, documents, etc… that might be relevant to the RFC.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Private question ❔
+    url: https://support.mui.com/hc/en-us/requests/new
+    about: I need to ask a question in private.


### PR DESCRIPTION
This is an attempt of moving more activity on the private email channels, e.g. figma@mui.com to an open channel.

How we will scale the support on GitHub? The same way we are doing for Material UI, MUI X, and MUI Toolpad.