### PR TITLE
[core] Update `no-response` workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,8 +1,10 @@
 name: No response
 
-# Both `issue_comment` and `scheduled` event types are required for this Action
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
 # to work properly.
 on:
+  issues:
+    types: [closed]
   issue_comment:
     types: [created]
   schedule:
@@ -16,13 +18,15 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: lee-dohm/no-response@v0.5.0
+      - uses: MBilalShafi/no-response-add-label@0.0.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: 'status: needs more information'
+          responseRequiredLabel: 'status: waiting for author'
+          # Label to add back when the `responseRequiredLabel` is removed
+          optionalFollowupLabel: 'status: waiting for maintainer'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed.


### PR DESCRIPTION
Addresses point # 4 of https://github.com/mui/mui-x/issues/10810

Just before merging this PR, the GitHub labels `status: waiting for author` and `status: waiting for maintainer` should be created.