### PR TITLE
[support-infra] Update status labels GitHub Actions

### DIFF
--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -2,8 +2,11 @@ name: Issue status label handler
 
 on:
   issue_comment:
+    # on 'issue_comment.created' we check if the comment comes from the author and remove the "status: waiting for author" label
+    # additionally we reopen the issue when it is closed and the author comments on it
     types: [created]
   issues:
+    # on 'issues.closed' events we simply remove the "status: waiting for author" or "status: waiting for maintainer" label
     types: [closed]
 
 permissions: {}

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,33 +1,19 @@
 name: No response
 
-# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
-# to work properly.
 on:
-  issues:
-    types: [closed]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # These runs in our repos are spread evenly throughout the day to avoid hitting rate limits.
+    # If you change this schedule, consider changing the remaining repositories as well.
+    # Runs at 3 am, 3 pm
+    - cron: '0 3,15 * * *'
+
+permissions: {}
 
 jobs:
   noResponse:
-    runs-on: ubuntu-latest
     permissions:
-      contents: read
       issues: write
-    steps:
-      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947 # v0.0.6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Number of days of inactivity before an Issue is closed for lack of response
-          daysUntilClose: 7
-          # Label requiring a response
-          responseRequiredLabel: 'status: waiting for author'
-          # Label to add back when the `responseRequiredLabel` is removed
-          optionalFollowupLabel: 'status: waiting for maintainer'
-          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
-          closeComment: >
-            Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed.
-            If you wish to see the issue reopened, please provide the missing information.
+      pull-requests: write
+    name: Handle stale issues and PRs
+    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@master

--- a/.github/workflows/remove-label-on-close.yml
+++ b/.github/workflows/remove-label-on-close.yml
@@ -1,15 +1,18 @@
-name: Remove Label When Closed
+name: Issue status label handler
 
 on:
+  issue_comment:
+    types: [created]
   issues:
     types: [closed]
 
+permissions: {}
+
 jobs:
-  remove-label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove specific label
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "status: waiting for maintainer"
+  statusHandling:
+    permissions:
+      contents: read
+      issues: write
+      actions: write
+    name: Handle status labels
+    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@master

--- a/.github/workflows/remove-label-on-close.yml
+++ b/.github/workflows/remove-label-on-close.yml
@@ -1,0 +1,15 @@
+name: Remove Label When Closed
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove specific label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "status: waiting for maintainer"


### PR DESCRIPTION
~Thought this might help. Summary: Created a workflow to automatically remove the status: waiting for maintainer label when an issue is closed.~
~Details:
Adds a GitHub Actions workflow that listens for the closed event on issues.
When triggered, it removes the status: waiting for maintainer label.~

Update the GitHub Actions to replicate https://github.com/mui/mui-public when it comes to:

 - managing the status labels
 - closing stale PRs and where issue authors don't give us key information to work on the issue.

It's one of https://github.com/mui/mui-public/issues/487.